### PR TITLE
update GUI wallet links

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ description: index_page.meta.description
                 <div><span class="process-icons pe-7s-users"></span></div>
                 <h2 class="mt15 mb20">TurtleCoin Mac</h2>
                 <p class="no-margin">
-                  <a href="https://github.com/turtlecoin/turtle-wallet-electron/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
+                  <a href="https://github.com/turtlecoin/turtle-wallet-proton/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
                   <br>
                   <a href="https://github.com/turtlecoin/turtlecoin/releases/latest">&nbsp;{% t index_page.download_cli %}</a>
                 </p>
@@ -164,7 +164,7 @@ description: index_page.meta.description
                 <div><span class="process-icons pe-7s-users"></span></div>
                 <h2 class="mt15 mb20">TurtleCoin Windows</h2>
                 <p class="no-margin">
-                  <a href="https://github.com/turtlecoin/turtle-wallet-electron/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
+                  <a href="https://github.com/turtlecoin/turtle-wallet-proton/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
                   <br>
                   <a href="https://github.com/turtlecoin/turtlecoin/releases/latest">&nbsp;{% t index_page.download_cli %}</a>
                 </p>
@@ -182,7 +182,7 @@ description: index_page.meta.description
                 <div><span class="process-icons pe-7s-users"></span></div>
                 <h2 class="mt15 mb20">TurtleCoin Linux</h2>
                 <p class="no-margin">
-                  <a href="https://github.com/turtlecoin/turtle-wallet-electron/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
+                  <a href="https://github.com/turtlecoin/turtle-wallet-proton/releases/latest">&nbsp;{% t index_page.download_gui %}</a>
                   <br>
                   <a href="https://github.com/turtlecoin/turtlecoin/releases/latest">&nbsp;{% t index_page.download_cli %}</a>
                 </p>


### PR DESCRIPTION
I'm suggesting we change these links to point to my GUI wallet instead of walletshell for these reasons:

1. It utilizes the new JS backend and as a result is much more responsive than walletshell
2. It appears the maintainer is still absent on wallet-shell
3. walletshell is based on turtle-service which is deprecated