### PR TITLE
Add a title to the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@ description: index_page.meta.description
 <!DOCTYPE html>
 <html lang="{{ site.lang }}">
 <head>
+
+  <!-- Title -->
+  <title>TurtleCoin</title>
+
+  <!-- Includes -->
   {% include meta.html %}
   {% include stylesheets.html %}
   {% include head_javascripts.html %}


### PR DESCRIPTION
The <title> tag was missing. I checked in every localization file and all of them used `TurtleCoin`. I also tried to add an index_page.title to the localization files but seems like it loads the title first before it loads any of the localization stuff. 