### PR TITLE
gems no longer used

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ exclude:
  - .bundle
  - vendor
 
-gems:
+plugins:
  - jekyll-multiple-languages-plugin
 
 


### PR DESCRIPTION
Deprecation: The 'gems' configuration option has been renamed to 'plugins . Updating the config file accordingly.                            '.