### PR TITLE
Removed unused panel CSS declarations

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -991,14 +991,12 @@ input[type="radio"] + label:before {
 }
 
 .image.filtered:after {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     pointer-events: none;
     content: "";
     position: absolute;
@@ -1011,15 +1009,13 @@ input[type="radio"] + label:before {
 }
 
 .image.filtered.tinted:after {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         ),
         linear-gradient(0deg, rgba(0, 0, 0, 0.125), rgba(0, 0, 0, 0.125));
-    background-size: 128px 128px, auto, auto;
 }
 
 .image[data-position] img {
@@ -2324,104 +2320,86 @@ button:disabled,
 }
 
 .panel > *.color0 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(45deg, #2d836d 20%, #49c085 60%, #d0e59d);
-    background-size: 128px 128px, auto;
+    background-image: linear-gradient(45deg, #2d836d 20%, #49c085 60%, #d0e59d);
 }
 
 .panel > *.color1 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #726193;
 }
 
 .panel > *.color2 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #e37b7c;
 }
 
 .panel > *.color3 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #ffe4b4;
 }
 
 .panel > *.color4 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #353865;
 }
 
 .panel > *.color1-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #6c5e86;
 }
 
 .panel > *.color2-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(123, 227, 137, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #2c816c;
 }
 
 .panel > *.color3-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #fedea6;
 }
 
 .panel > *.color4-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #323459;
 }
 
@@ -2970,104 +2948,86 @@ button:disabled,
 }
 
 .panel.color0 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(45deg, #726193 20%, #e37b7c 60%, #ffe4b4);
-    background-size: 128px 128px, auto;
+    background-image: linear-gradient(45deg, #726193 20%, #e37b7c 60%, #ffe4b4);
 }
 
 .panel.color1 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #726193;
 }
 
 .panel.color2 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #b46c72;
 }
 
 .panel.color3 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #ffe4b4;
 }
 
 .panel.color4 {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.25) 25%,
             rgba(227, 123, 124, 0.25) 50%,
             rgba(255, 228, 180, 0.25)
         );
-    background-size: 128px 128px, auto;
     background-color: #353865;
 }
 
 .panel.color1-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #6c5e86;
 }
 
 .panel.color2-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #2c816c;
 }
 
 .panel.color3-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #fedea6;
 }
 
 .panel.color4-alt {
-    background-image: url("../../images/overlay.png"),
-        linear-gradient(
+    background-image: linear-gradient(
             45deg,
             rgba(114, 97, 147, 0.175) 25%,
             rgba(227, 123, 124, 0.175) 50%,
             rgba(255, 228, 180, 0.175)
         );
-    background-size: 128px 128px, auto;
     background-color: #323459;
 }
 
@@ -3081,98 +3041,82 @@ button:disabled,
     }
 
     .panel > *.color1 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #726193;
     }
 
     .panel > *.color2 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #e37b7c;
     }
 
     .panel > *.color3 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #ffe4b4;
     }
 
     .panel > *.color4 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #353865;
     }
 
     .panel > *.color1-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #6c5e86;
     }
 
     .panel > *.color2-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #8bcc8c;
     }
 
     .panel > *.color3-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #fedea6;
     }
 
     .panel > *.color4-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #323459;
     }
 
@@ -3638,98 +3582,82 @@ button:disabled,
     }
 
     .panel.color1 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #726193;
     }
 
     .panel.color2 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #e37b7c;
     }
 
     .panel.color3 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #ffe4b4;
     }
 
     .panel.color4 {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.25) 25%,
                 rgba(227, 123, 124, 0.25) 50%,
                 rgba(255, 228, 180, 0.25)
             );
-        background-size: 128px 128px, auto;
         background-color: #353865;
     }
 
     .panel.color1-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #6c5e86;
     }
 
     .panel.color2-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #8bcc8c;
     }
 
     .panel.color3-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #fedea6;
     }
 
     .panel.color4-alt {
-        background-image: url("../../images/overlay.png"),
-            linear-gradient(
+        background-image: linear-gradient(
                 135deg,
                 rgba(114, 97, 147, 0.175) 25%,
                 rgba(227, 123, 124, 0.175) 50%,
                 rgba(255, 228, 180, 0.175)
             );
-        background-size: 128px 128px, auto;
         background-color: #323459;
     }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -304,12 +304,7 @@ body:after {
     width: 100%;
     height: 100%;
     z-index: -1;
-    background-attachment: fixed;
     background-color: #e1e6e1;
-    background-image: url("../../images/overlay.png"),
-        url("../../images/bg.jpg");
-    background-repeat: repeat, repeat-x;
-    background-size: 128px 128px, cover;
 }
 
 body.is-preload *,


### PR DESCRIPTION
Removed all the broken 'background-image', and unused 'background-size' from '.panel' declarations.

Some extra fixes related to #105 