### PR TITLE
Fix overflow scroll and core commits height on desktop

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -523,7 +523,7 @@ sup {
 }
 
 #github-commits li {
-	max-height: 5.25rem;
+    max-height: 5.25rem;
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -539,7 +539,7 @@ blockquote {
 }
 @media screen and (max-width: 736px) {
     blockquote,
-	#github-commits li {
+    #github-commits li {
         max-height: 100%;
     }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -522,6 +522,12 @@ sup {
     top: -0.5rem;
 }
 
+#github-commits li {
+	max-height: 5.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 blockquote {
     border-left: solid 0.25rem rgba(255, 255, 255, 0.25);
     font-style: italic;
@@ -532,7 +538,8 @@ blockquote {
     text-overflow: ellipsis;
 }
 @media screen and (max-width: 736px) {
-    blockquote {
+    blockquote,
+	#github-commits li {
         max-height: 100%;
     }
 }


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/8020386/90619694-1d924480-e244-11ea-85f3-31f1fb6573b4.png)

## After:
![image](https://user-images.githubusercontent.com/8020386/90619712-2125cb80-e244-11ea-9d57-a45b7896c854.png)
