### PR TITLE
Add an Italian Translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ gems:
 
 # Localization config
 
-languages: ["en", "de", "es", "fr", "he", "pt-br", "tr", "zh", "nl"]
+languages: ["en", "de", "es", "fr", "he", "pt-br", "tr", "zh", "nl", "it"]
 
 language_names:
   en:
@@ -46,6 +46,9 @@ language_names:
   nl:
     short: nl
     full: Dutch
+  it:
+    short: it
+    full: Italian
   # dev:
   #   short: dev
   #   full: Development

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -8,9 +8,9 @@ get_started: Inizia subito in <strong>3 semplici passi.</strong>
 
 
 # wallet section
-wallet_title: Apri un Wallet
+wallet_title: Apri un Portafoglio Digitale
 wallet_we_support: La nostra app è disponibile su <strong>Windows, MacOS, Linux, e Android</strong>, in versione <strong><a href="http://latest.turtlecoin.lol">CLI</a> o sul Browser</strong>.
-wallet_long_term_storage: Per utilizzo a lungo termine, consigliamo l'uso di un <strong><a href="/wallet">wallet cartaceo</a></strong>.
+wallet_long_term_storage: Per utilizzo a lungo termine, consigliamo l'uso di un <strong><a href="/wallet">portafoglio cartaceo</a></strong>.
 
 #say hello section
 say_hello_title: Vieni a Trovarci

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -17,7 +17,7 @@ say_hello_title: Vieni a Trovarci
 
 #get in the know section
 get_know_title: Scopri di Più
-get_know_text: Pubblichiamo nuovi articoli ogni settimana sul <strong><a href="https://blog.turtlecoin.lol">Blog ufficiale di <span class="reg">TurtleCoin</span></a></strong> condividendo nel dettaglio i nostri risultati. Nel caso tu voglia scrivere di un tuo progetto, condividere le tue esperienze con il progetto, o semplicemente far parte della nostra comunità, sono tutti libieri di pubblicare un proprio articolo sul blog.
+get_know_text: Pubblichiamo nuovi articoli ogni settimana sul <strong><a href="https://blog.turtlecoin.lol">Blog ufficiale di <span class="reg">TurtleCoin</span></a></strong> condividendo nel dettaglio i nostri risultati. Nel caso tu voglia scrivere di un tuo progetto, condividere le tue esperienze con il progetto, o semplicemente far parte della nostra comunità, sono tutti liberi di pubblicare un proprio articolo sul blog.
 get_know_button: Scrivi un post
 
 #blog updates section

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -24,7 +24,7 @@ get_know_button: Scrivi un post
 blog_updates_title: Articoli Recenti
 
 #dev activity section
-dev_activity_title: Ultime Attività degli Sviluppatori
+dev_activity_title: Ultimi Sviluppi
 dev_activity_issues: Problemi
 dev_activity_core_commits: Core Commits
 

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -1,0 +1,35 @@
+meta:
+  description: TurtleCoin è una moneta elettronica Peer-2-Peer ed Open Source. È semplice da usare, completamente anonima, e divertente.
+  title: TurtleCoin
+
+# welcome section
+turtlecoin_is: TurtleCoin</span> è una moneta elettronica <strong>Peer-2-Peer</strong> ed <a href="https://github.com/turtlecoin">Open Source</a>. È <a href="https://docs.turtlecoin.lol/">semplice da usare</a>, <strong>completamente anonima</strong>, e divertente.
+get_started: Inizia subito in <strong>3 semplici passi.</strong>
+
+
+# wallet section
+wallet_title: Apri un Portafoglio
+wallet_we_support: La nostra app è disponibile su <strong>Windows, MacOS, Linux, e Android</strong>, in versione <strong><a href="http://latest.turtlecoin.lol">CLI</a> o sul Browser</strong>.
+wallet_long_term_storage: Per utilizzo a lungo termine, consigliamo l'uso di un <strong><a href="/wallet">portafoglio cartaceo</a></strong>.
+
+#say hello section
+say_hello_title: Vieni a Trovarci
+
+#get in the know section
+get_know_title: Scopri di Più
+get_know_text: Pubblichiamo nuovi articoli ogni settimana sul <strong><a href="https://blog.turtlecoin.lol">Blog ufficiale di <span class="reg">TurtleCoin</span></a></strong> condividendo nel dettaglio i nostri risultati. Nel caso tu voglia scrivere di un tuo progetto, condividere le tue esperienze con il progetto, o semplicemente far parte della nostra comunità, sono tutti libieri di pubblicare un proprio articolo sul blog.
+get_know_button: Scrivi un post
+
+#blog updates section
+blog_updates_title: Articoli Recenti
+
+#dev activity section
+dev_activity_title: Ultime Attività degli Sviluppatori
+dev_activity_issues: Problemi
+dev_activity_core_commits: Core Commits
+
+#building apps section
+building_apps_title: Sviluppare App con
+building_apps_text: <span class="reg">TurtleCoin</span> offre diversi servizi ed una documentazione completa per aiutare gli sviluppatori ad integrare le nostre API nelle loro app. Ecco dei link per aiutarvi.
+building_apps_api_doc:  <span class="reg">TurtleCoin</span>Documentaione delle API
+building_apps_service_doc: Documentazione dei Servizi di<span class="reg">TurtleCoin</span>

--- a/_i18n/it.yml
+++ b/_i18n/it.yml
@@ -8,9 +8,9 @@ get_started: Inizia subito in <strong>3 semplici passi.</strong>
 
 
 # wallet section
-wallet_title: Apri un Portafoglio
+wallet_title: Apri un Wallet
 wallet_we_support: La nostra app è disponibile su <strong>Windows, MacOS, Linux, e Android</strong>, in versione <strong><a href="http://latest.turtlecoin.lol">CLI</a> o sul Browser</strong>.
-wallet_long_term_storage: Per utilizzo a lungo termine, consigliamo l'uso di un <strong><a href="/wallet">portafoglio cartaceo</a></strong>.
+wallet_long_term_storage: Per utilizzo a lungo termine, consigliamo l'uso di un <strong><a href="/wallet">wallet cartaceo</a></strong>.
 
 #say hello section
 say_hello_title: Vieni a Trovarci


### PR DESCRIPTION
I had to use a different sentence structure or slightly different terms compared to the English version in order to have everything read smoothly, but I think I did a pretty good job. The only part I wasn't sure of was how I should translate "electronic currency", as I assumed its use implied the author's preference not to present TurtleCoin as a cryptocurrency (maybe due to a perceived negative connotation?), so I opted for "moneta elettronica" instead of the much more common "criptovaluta", as Wikipedia uses "elettronica" rather than "digitale" on [this article](https://it.wikipedia.org/wiki/Denaro_elettronico) and "moneta" seemed more appropriate than "denaro" (typically used for physical fiat currency) while sounding much friendlier than "valuta", maintaining a good vibe without sounding unprofessional.